### PR TITLE
Add the ability to specify MaxDuration instead of Attempts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,8 @@ function finishing due to the total waiting duration exceeding the specified
 func LastError(err error) error
 ```
 LastError retrieves the last error returned from `Func` before iteration
-was terminated due to the maximum attempt count or maximum wait time being
-exceeded, or the stop channel being closed.
+was terminated due to the attempt count being exceeded, the maximum wait
+time being exceeded, or the stop channel being closed.
 
 
 

--- a/README.md
+++ b/README.md
@@ -123,14 +123,6 @@ const (
 )
 ```
 
-## Variables
-``` go
-var (
-    // RetryStopped is the error that is returned from the retry functions
-    // when the stop channel has been closed.
-    RetryStopped = errors.New("retry stopped")
-)
-```
 
 ## func Call
 ``` go
@@ -153,44 +145,34 @@ structure.
 ``` go
 func IsAttemptsExceeded(err error) bool
 ```
-IsAttemptsExceeded returns true if the error is a AttemptsExceeded
-error.
+IsAttemptsExceeded returns true if the error is the result of the `Call`
+function finishing due to hitting the requested number of `Attempts`.
 
 
 ## func IsRetryStopped
 ``` go
 func IsRetryStopped(err error) bool
 ```
-IsRetryStopped returns true if the error is RetryStopped.
+IsRetryStopped returns true if the error is the result of the `Call`
+function finishing due to the stop channel being closed.
 
 
-
-## type AttemptsExceeded
+## func IsWaitTimeExceeded
 ``` go
-type AttemptsExceeded struct {
-    LastError error
-}
+func IsWaitTimeExceeded(err error) bool
 ```
-AttemptsExceeded is the error that is returned when the retry count has
-been hit without the function returning a nil error result. The last error
-returned from the function being retried is available as the LastError
-attribute.
+IsWaitTimeExceeded returns true if the error is the result of the `Call`
+function finishing due to the total waiting duration exceeding the specified
+`MaxWait` value.
 
 
-
-
-
-
-
-
-
-
-
-### func (\*AttemptsExceeded) Error
+## func LastError
 ``` go
-func (e *AttemptsExceeded) Error() string
+func LastError(err error) error
 ```
-Error provides the implementation for the error interface method.
+LastError retrieves the last error returned from `Func` before iteration
+was terminated due to the maximum attempt count or maximum wait time being
+exceeded, or the stop channel being closed.
 
 
 
@@ -221,6 +203,13 @@ type CallArgs struct {
     // MaxDelay specifies how longest time to wait between retries. If no
     // value is specified there is no maximum delay.
     MaxDelay time.Duration
+
+    // MaxWait specifies the maximum time the Call function should wait. The
+    // wait time is the summation of the delays over the attempts. If the next
+    // delay time would take the total waiting duration over MaxWait, then an
+    // WaitTimeExceeded error is returned. If no value is specified, Call will
+    // continue until the number of attempts is complete.
+    MaxWait time.Duration
 
     // BackoffFunc allows the caller to provide a function that alters the
     // delay each time through the loop. If this function is not provided the

--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ IsAttemptsExceeded returns true if the error is the result of the `Call`
 function finishing due to hitting the requested number of `Attempts`.
 
 
+## func IsDurationExceeded
+``` go
+func IsDurationExceeded(err error) bool
+```
+IsDurationExceeded returns true if the error is the result of the `Call`
+function finishing due to the total duration exceeding the specified
+`MaxDuration` value.
+
+
 ## func IsRetryStopped
 ``` go
 func IsRetryStopped(err error) bool
@@ -157,22 +166,13 @@ IsRetryStopped returns true if the error is the result of the `Call`
 function finishing due to the stop channel being closed.
 
 
-## func IsWaitTimeExceeded
-``` go
-func IsWaitTimeExceeded(err error) bool
-```
-IsWaitTimeExceeded returns true if the error is the result of the `Call`
-function finishing due to the total waiting duration exceeding the specified
-`MaxWait` value.
-
-
 ## func LastError
 ``` go
 func LastError(err error) error
 ```
 LastError retrieves the last error returned from `Func` before iteration
-was terminated due to the attempt count being exceeded, the maximum wait
-time being exceeded, or the stop channel being closed.
+was terminated due to the attempt count being exceeded, the maximum
+duration being exceeded, or the stop channel being closed.
 
 
 
@@ -204,12 +204,13 @@ type CallArgs struct {
     // value is specified there is no maximum delay.
     MaxDelay time.Duration
 
-    // MaxWait specifies the maximum time the Call function should wait. The
-    // wait time is the summation of the delays over the attempts. If the next
-    // delay time would take the total waiting duration over MaxWait, then an
-    // WaitTimeExceeded error is returned. If no value is specified, Call will
-    // continue until the number of attempts is complete.
-    MaxWait time.Duration
+    // MaxDuration specifies the maximum time the `Call` function should spend
+    // iterating over `Func`. The duration is calculated from the start of the
+    // `Call` function.  If the next delay time would take the total duration
+    // of the call over MaxDuration, then a DurationExceeded error is
+    // returned. If no value is specified, Call will continue until the number
+    // of attempts is complete.
+    MaxDuration time.Duration
 
     // BackoffFunc allows the caller to provide a function that alters the
     // delay each time through the loop. If this function is not provided the

--- a/retry.go
+++ b/retry.go
@@ -55,8 +55,8 @@ func (e *waitTimeExceeded) Error() string {
 }
 
 // LastError retrieves the last error returned from `Func` before iteration
-// was terminated due to the maximum attempt count or maximum wait time being
-// exceeded, or the stop channel being closed.
+// was terminated due to the attempt count being exceeded, the maximum wait
+// time being exceeded, or the stop channel being closed.
 func LastError(err error) error {
 	cause := errors.Cause(err)
 	switch err := cause.(type) {

--- a/retry_test.go
+++ b/retry_test.go
@@ -27,9 +27,6 @@ type mockClock struct {
 }
 
 func (mock *mockClock) Now() time.Time {
-	if mock.now.IsZero() {
-		mock.now = time.Now()
-	}
 	return mock.now
 }
 


### PR DESCRIPTION
During the initial work to add to juju/juju, it became apparent that being able to specify a MaxDuration rather than an Attempt count is desirable.