### PR TITLE
Define a local clock interface.

### DIFF
--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,16 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package retry
+
+import "time"
+
+// Clock provides an interface for dealing with clocks.
+type Clock interface {
+	// Now returns the current clock time.
+	Now() time.Time
+
+	// After waits for the duration to elapse and then sends the
+	// current time on the returned channel.
+	After(time.Duration) <-chan time.Time
+}

--- a/retry.go
+++ b/retry.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/juju/errors"
-	"github.com/juju/utils/clock"
 )
 
 const (
@@ -142,7 +141,7 @@ type CallArgs struct {
 	// Clock provides the mechanism for waiting. Normal program execution is
 	// expected to use something like clock.WallClock, and tests can override
 	// this to not actually sleep in tests.
-	Clock clock.Clock
+	Clock Clock
 
 	// Stop is a channel that can be used to indicate that the waiting should
 	// be interrupted. If Stop is nil, then the Call function cannot be interrupted.


### PR DESCRIPTION
Instead of bringing in github.com/juju/utils/clock for the interface, just define the Clock interface here.