### PR TITLE
fix: cleanup our handling of jitter and other misc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -13,10 +13,10 @@
 //	})
 //
 // The bare minimum arguments that need to be specified are:
-//  * Func - the function to call
-//  * Attempts - the number of times to try Func before giving up, or a negative number for unlimited attempts (`retry.UnlimitedAttempts`)
-//  * Delay - how long to wait between each try that returns an error
-//  * Clock - either the wall clock, or some testing clock
+//   - Func - the function to call
+//   - Attempts - the number of times to try Func before giving up, or a negative number for unlimited attempts (`retry.UnlimitedAttempts`)
+//   - Delay - how long to wait between each try that returns an error
+//   - Clock - either the wall clock, or some testing clock
 //
 // Any error that is returned from the Func is considered transient.
 // In order to identify some errors as fatal, pass in a function for the
@@ -87,5 +87,4 @@
 //		Delay:       100 * time.Millisecond,
 //		Clock:       clock.WallClock,
 //	})
-//
 package retry

--- a/retry.go
+++ b/retry.go
@@ -248,9 +248,9 @@ func ExpBackoff(minDelay, maxDelay time.Duration, exp float64, applyJitter bool)
 			// We want to go +/- 20%, which is a 40% swing, and
 			// Float64 returns in the range 0-1
 			newDelay = (1 + rand.Float64()*0.4 - 0.2) * newDelay
-			if newDelay < minDelayF {
-				newDelay = minDelayF
-			}
+		}
+		if newDelay < minDelayF {
+			newDelay = minDelayF
 		}
 		if newDelay > maxDelayF {
 			newDelay = maxDelayF

--- a/retry.go
+++ b/retry.go
@@ -232,7 +232,8 @@ func DoubleDelay(delay time.Duration, attempt int) time.Duration {
 // structure.
 //
 // The next delay value is calculated using the following formula:
-//   newDelay = min(minDelay * exp^attempt, maxDelay)
+//
+//	newDelay = min(minDelay * exp^attempt, maxDelay)
 //
 // If applyJitter is set to true, the function will randomly select and return
 // back a value in the [minDelay, newDelay] range.
@@ -241,18 +242,19 @@ func ExpBackoff(minDelay, maxDelay time.Duration, exp float64, applyJitter bool)
 	maxDelayF := float64(maxDelay)
 	return func(_ time.Duration, attempt int) time.Duration {
 		newDelay := minDelayF * math.Pow(exp, float64(attempt))
-		if newDelay > maxDelayF {
-			newDelay = maxDelayF
-		}
 
 		// Return a random value in the [minDelay, newDelay) range.
 		if applyJitter {
-			newDelay = rand.Float64() * newDelay
+			// We want to go +/- 20%, which is a 40% swing, and
+			// Float64 returns in the range 0-1
+			newDelay = (1 + rand.Float64()*0.4 - 0.2) * newDelay
 			if newDelay < minDelayF {
 				newDelay = minDelayF
 			}
 		}
-
+		if newDelay > maxDelayF {
+			newDelay = maxDelayF
+		}
 		return time.Duration(newDelay).Round(time.Millisecond)
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -413,7 +413,7 @@ func (*expBackoffSuite) TestExpBackofWithJitterAverage(c *gc.C) {
 // max values.
 func (*expBackoffSuite) TestExpBackoffBadExponent(c *gc.C) {
 	const (
-		// 1.02^100 ~= 10, causing us to go from 200ms to 2s in 100 steps
+		// a backoff of 0.8 would put us below 200ms
 		minDelay    = 200 * time.Millisecond
 		maxDelay    = 2 * time.Second
 		maxAttempts = 10


### PR DESCRIPTION
The original implementation of jitter computed the new delay, and then did a range of actual delay in the range of 0-100% of that value. On average, that actually means that we delay 1/2 as long as the desired values. In practice it was slightly more, because we then capped to min and max, which meant for the simple tests it was a 60% bias.

The new algorithm does a +/- 20% logic, which means that on average, we actually end up very close to the expected values (my averaging ratios normally came out within 1% of the expected values, and worse case was about a 3.6% bias). Since it is random, it could be anything (you could have a string of 100 minimum possible values). But that is unlikely enough that I'll leave the test suite as asserting we are within 10% and live with the 1 in 1 billion chance that it fails.

Also, there was a flaky test (StopChannel) where it could get an extra trigger sometimes, and we had the bug that if a user incorrectly supplied a exponential backoff that was <1.0 we would actually end up going below minDelay, rather than capping it at min. (we would check if you applied jitter, but not normally).

There isn't a lot to QA manually, as I think the test cases are pretty thorough.

I'm a bit unhappy about my "1ms" limits on the 20% over and under, but I think that is still ok. Certainly it is ok in practice.
